### PR TITLE
Avoid an obvious array indexing bug

### DIFF
--- a/matlab/cmg/cmg_precondition.m
+++ b/matlab/cmg/cmg_precondition.m
@@ -185,10 +185,13 @@ function [pfun, H, flag] = cmg_precondition(A,opts)
     for k=1:(j-2)
        H{k}.repeat = max(floor(nnz(H{k}.A)/nnz(H{k+1}.A)-1),1);
     end
-    if flag == 0
-        H{j-1}.repeat = max(floor(nnz(H{j-1}.A)/nnz(H{j}.chol.ld)-1),1);
-    else
-        H{j-1}.repeat = max(floor(nnz(H{j-1}.A)/nnz(H{j}.A)-1),1);
+    if j > 1
+        if flag == 0
+            H{j-1}.repeat = max(floor(nnz(H{j-1}.A)/nnz(H{j}.chol.ld)-1),1);
+        else
+            H{j-1}.repeat = max(floor(nnz(H{j-1}.A)/nnz(H{j}.A)-1),1);
+        end
+    % TODO: else
     end
     
     % H = cell2mat(H);


### PR DESCRIPTION
It was first introduced [in this commit](https://github.com/pratyai/cmg-solver/commit/991d3da7068390222e8cde479a1b7c5c22b00b23).

If for whatever reason (e.g. due to full contraction or stagnation), the `flag` is set to non-zero at the very first level (i.e. `j = 1`), then the program just crashes with an array indexing error now.

Example: `cmg_sdd(speye(1000))` would break before, but not after this patch.